### PR TITLE
Enable tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "master"
       - "v3"
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   spec:
@@ -17,6 +20,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
           - "head"
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,4 +32,4 @@ jobs:
         bundler-cache: true
 
     - name: Run Tests
-      run: bundle exec rake
+      run: bundle exec rspec

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         ruby_version:
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"

--- a/spec/support/lint.rb
+++ b/spec/support/lint.rb
@@ -1,18 +1,18 @@
 shared_examples :lint do
   let(:interactor) { Class.new.send(:include, described_class) }
 
-  describe ".call" do
+  describe '.call' do
     let(:context) { double(:context) }
     let(:instance) { double(:instance, context: context) }
 
-    it "calls an instance with the given context" do
-      expect(interactor).to receive(:new).once.with(foo: "bar") { instance }
+    it 'calls an instance with the given context' do
+      expect(interactor).to receive(:new).once.with({ foo: 'bar' }) { instance }
       expect(instance).to receive(:run).once.with(no_args)
 
-      expect(interactor.call(foo: "bar")).to eq(context)
+      expect(interactor.call(foo: 'bar')).to eq(context)
     end
 
-    it "provides a blank context if none is given" do
+    it 'provides a blank context if none is given' do
       expect(interactor).to receive(:new).once.with({}) { instance }
       expect(instance).to receive(:run).once.with(no_args)
 
@@ -20,18 +20,18 @@ shared_examples :lint do
     end
   end
 
-  describe ".call!" do
+  describe '.call!' do
     let(:context) { double(:context) }
     let(:instance) { double(:instance, context: context) }
 
-    it "calls an instance with the given context" do
-      expect(interactor).to receive(:new).once.with(foo: "bar") { instance }
+    it 'calls an instance with the given context' do
+      expect(interactor).to receive(:new).once.with({ foo: 'bar' }) { instance }
       expect(instance).to receive(:run!).once.with(no_args)
 
-      expect(interactor.call!(foo: "bar")).to eq(context)
+      expect(interactor.call!(foo: 'bar')).to eq(context)
     end
 
-    it "provides a blank context if none is given" do
+    it 'provides a blank context if none is given' do
       expect(interactor).to receive(:new).once.with({}) { instance }
       expect(instance).to receive(:run!).once.with(no_args)
 
@@ -39,19 +39,19 @@ shared_examples :lint do
     end
   end
 
-  describe ".new" do
+  describe '.new' do
     let(:context) { double(:context) }
 
-    it "initializes a context" do
-      expect(Interactor::Context).to receive(:build).once.with(foo: "bar") { context }
+    it 'initializes a context' do
+      expect(Interactor::Context).to receive(:build).once.with({ foo: 'bar' }) { context }
 
-      instance = interactor.new(foo: "bar")
+      instance = interactor.new(foo: 'bar')
 
       expect(instance).to be_a(interactor)
       expect(instance.context).to eq(context)
     end
 
-    it "initializes a blank context if none is given" do
+    it 'initializes a blank context if none is given' do
       expect(Interactor::Context).to receive(:build).once.with({}) { context }
 
       instance = interactor.new
@@ -61,80 +61,80 @@ shared_examples :lint do
     end
   end
 
-  describe "#run" do
+  describe '#run' do
     let(:instance) { interactor.new }
 
-    it "runs the interactor" do
+    it 'runs the interactor' do
       expect(instance).to receive(:run!).once.with(no_args)
 
       instance.run
     end
 
-    it "rescues failure with the same context" do
+    it 'rescues failure with the same context' do
       expect(instance).to receive(:run!).and_raise(Interactor::Failure.new(instance.context))
 
-      expect {
+      expect do
         instance.run
-      }.not_to raise_error
+      end.not_to raise_error
     end
 
-    it "raises other failures" do
+    it 'raises other failures' do
       expect(instance).to receive(:run!).and_raise(Interactor::Failure.new(Interactor::Context.new))
 
-      expect {
+      expect do
         instance.run
-      }.to raise_error(Interactor::Failure)
+      end.to raise_error(Interactor::Failure)
     end
 
-    it "raises other errors" do
-      expect(instance).to receive(:run!).and_raise("foo")
+    it 'raises other errors' do
+      expect(instance).to receive(:run!).and_raise('foo')
 
-      expect {
+      expect do
         instance.run
-      }.to raise_error("foo")
+      end.to raise_error('foo')
     end
   end
 
-  describe "#run!" do
+  describe '#run!' do
     let(:instance) { interactor.new }
 
-    it "calls the interactor" do
+    it 'calls the interactor' do
       expect(instance).to receive(:call).once.with(no_args)
 
       instance.run!
     end
 
-    it "raises failure" do
+    it 'raises failure' do
       expect(instance).to receive(:run!).and_raise(Interactor::Failure)
 
-      expect {
+      expect do
         instance.run!
-      }.to raise_error(Interactor::Failure)
+      end.to raise_error(Interactor::Failure)
     end
 
-    it "raises other errors" do
-      expect(instance).to receive(:run!).and_raise("foo")
+    it 'raises other errors' do
+      expect(instance).to receive(:run!).and_raise('foo')
 
-      expect {
+      expect do
         instance.run
-      }.to raise_error("foo")
+      end.to raise_error('foo')
     end
   end
 
-  describe "#call" do
+  describe '#call' do
     let(:instance) { interactor.new }
 
-    it "exists" do
+    it 'exists' do
       expect(instance).to respond_to(:call)
       expect { instance.call }.not_to raise_error
       expect { instance.method(:call) }.not_to raise_error
     end
   end
 
-  describe "#rollback" do
+  describe '#rollback' do
     let(:instance) { interactor.new }
 
-    it "exists" do
+    it 'exists' do
       expect(instance).to respond_to(:rollback)
       expect { instance.rollback }.not_to raise_error
       expect { instance.method(:rollback) }.not_to raise_error


### PR DESCRIPTION
Fix those tests:

```
Run bundle exec rspec

Randomized with seed 3012
...........................................................................FF..........F.........F.F.F......

Failures:

  1) Interactor::Organizer.call! calls an instance with the given context
     Failure/Error: new(context).tap(&:run!).context

       #<#<Class:0x000055fdc8[4](https://github.com/mjacobus/interactor/actions/runs/6632061126/job/18016930455?pr=1#step:4:5)a3e10> (class)> received :new with unexpected arguments
         expected: ({:foo=>"bar"}) (keyword arguments)
              got: ({:foo=>"bar"}) (options hash)
     Shared Example Group: :lint called from ./spec/interactor/organizer_spec.rb:3
     # ./lib/interactor.rb:76:in `call!'
     # ./spec/support/lint.rb:31:in `block (3 levels) in <top (required)>'

  2) Interactor::Organizer.call calls an instance with the given context
     Failure/Error: new(context).tap(&:run).context

       #<#<Class:0x0000[5](https://github.com/mjacobus/interactor/actions/runs/6632061126/job/18016930455?pr=1#step:4:6)5fdc85511a0> (class)> received :new with unexpected arguments
         expected: ({:foo=>"bar"}) (keyword arguments)
              got: ({:foo=>"bar"}) (options hash)
     Shared Example Group: :lint called from ./spec/interactor/organizer_spec.rb:3
     # ./lib/interactor.rb:50:in `call'
     # ./spec/support/lint.rb:12:in `block (3 levels) in <top (required)>'

  3) Interactor::Organizer.new initializes a context
     Failure/Error: @context = Context.build(context)

       #<Interactor::Context (class)> received :build with unexpected arguments
         expected: ({:foo=>"bar"}) (keyword arguments)
              got: ({:foo=>"bar"}) (options hash)
     Shared Example Group: :lint called from ./spec/interactor/organizer_spec.rb:3
     # ./lib/interactor.rb:94:in `initialize'
     # ./spec/support/lint.rb:48:in `new'
     # ./spec/support/lint.rb:48:in `block (3 levels) in <top (required)>'

  4) Interactor.call calls an instance with the given context
     Failure/Error: new(context).tap(&:run).context

       #<#<Class:0x000055fdc8[6](https://github.com/mjacobus/interactor/actions/runs/6632061126/job/18016930455?pr=1#step:4:7)68340> (class)> received :new with unexpected arguments
         expected: ({:foo=>"bar"}) (keyword arguments)
              got: ({:foo=>"bar"}) (options hash)
     Shared Example Group: :lint called from ./spec/interactor_spec.rb:2
     # ./lib/interactor.rb:50:in `call'
     # ./spec/support/lint.rb:12:in `block (3 levels) in <top (required)>'

  5) Interactor.new initializes a context
     Failure/Error: @context = Context.build(context)

       #<Interactor::Context (class)> received :build with unexpected arguments
         expected: ({:foo=>"bar"}) (keyword arguments)
              got: ({:foo=>"bar"}) (options hash)
     Shared Example Group: :lint called from ./spec/interactor_spec.rb:2
     # ./lib/interactor.rb:94:in `initialize'
     # ./spec/support/lint.rb:48:in `new'
     # ./spec/support/lint.rb:48:in `block (3 levels) in <top (required)>'

  6) Interactor.call! calls an instance with the given context
     Failure/Error: new(context).tap(&:run!).context

       #<#<Class:0x000055fdc[7](https://github.com/mjacobus/interactor/actions/runs/6632061126/job/18016930455?pr=1#step:4:8)da6e50> (class)> received :new with unexpected arguments
         expected: ({:foo=>"bar"}) (keyword arguments)
              got: ({:foo=>"bar"}) (options hash)
     Shared Example Group: :lint called from ./spec/interactor_spec.rb:2
     # ./lib/interactor.rb:76:in `call!'
     # ./spec/support/lint.rb:31:in `block (3 levels) in <top (required)>'

Finished in 0.09336 seconds (files took 0.1073[8](https://github.com/mjacobus/interactor/actions/runs/6632061126/job/18016930455?pr=1#step:4:9) seconds to load)
[10](https://github.com/mjacobus/interactor/actions/runs/6632061126/job/18016930455?pr=1#step:4:11)8 examples, 6 failures

Failed examples:

rspec './spec/interactor/organizer_spec.rb[1:2:1]' # Interactor::Organizer.call! calls an instance with the given context
rspec './spec/interactor/organizer_spec.rb[1:1:1]' # Interactor::Organizer.call calls an instance with the given context
rspec './spec/interactor/organizer_spec.rb[1:3:1]' # Interactor::Organizer.new initializes a context
rspec './spec/interactor_spec.rb[1:1:1]' # Interactor.call calls an instance with the given context
rspec './spec/interactor_spec.rb[1:3:1]' # Interactor.new initializes a context
rspec './spec/interactor_spec.rb[1:2:1]' # Interactor.call! calls an instance with the given context
```