### PR TITLE
Run tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "master"
       - "v3"
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   spec:
@@ -13,10 +16,10 @@ jobs:
     strategy:
       matrix:
         ruby_version:
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
           - "head"
 
     steps:
@@ -29,4 +32,4 @@ jobs:
         bundler-cache: true
 
     - name: Run Tests
-      run: bundle exec rake
+      run: bundle exec rspec

--- a/spec/support/lint.rb
+++ b/spec/support/lint.rb
@@ -6,7 +6,7 @@ shared_examples :lint do
     let(:instance) { double(:instance, context: context) }
 
     it "calls an instance with the given context" do
-      expect(interactor).to receive(:new).once.with(foo: "bar") { instance }
+      expect(interactor).to receive(:new).once.with({ foo: "bar" }) { instance }
       expect(instance).to receive(:run).once.with(no_args)
 
       expect(interactor.call(foo: "bar")).to eq(context)
@@ -25,7 +25,7 @@ shared_examples :lint do
     let(:instance) { double(:instance, context: context) }
 
     it "calls an instance with the given context" do
-      expect(interactor).to receive(:new).once.with(foo: "bar") { instance }
+      expect(interactor).to receive(:new).once.with({ foo: "bar" }) { instance }
       expect(instance).to receive(:run!).once.with(no_args)
 
       expect(interactor.call!(foo: "bar")).to eq(context)
@@ -43,7 +43,7 @@ shared_examples :lint do
     let(:context) { double(:context) }
 
     it "initializes a context" do
-      expect(Interactor::Context).to receive(:build).once.with(foo: "bar") { context }
+      expect(Interactor::Context).to receive(:build).once.with({ foo: "bar" }) { context }
 
       instance = interactor.new(foo: "bar")
 


### PR DESCRIPTION
Fix this type of failure:

```txt
bundle exec rspec

Randomized with seed 58625
.............F...F...........F.....................F....F.......F...........................................

Failures:

  1) Interactor::Organizer.call! calls an instance with the given context
     Failure/Error: new(context).tap(&:run!).context

       #<#<Class:0x000055ff603705b8> (class)> received :new with unexpected arguments
         expected: ({:foo=>"bar"}) (keyword arguments)
              got: ({:foo=>"bar"}) (options hash)
     Shared Example Group: :lint called from ./spec/interactor/organizer_spec.rb:3
     # ./lib/interactor.rb:76:in `call!'
     # ./spec/support/lint.rb:31:in `block (3 levels) in <top (required)>'

  2) Interactor::Organizer.call calls an instance with the given context
     Failure/Error: new(context).tap(&:run).context

       #<#<Class:0x000055ff6070bee8> (class)> received :new with unexpected arguments
         expected: ({:foo=>"bar"}) (keyword arguments)
              got: ({:foo=>"bar"}) (options hash)
     Shared Example Group: :lint called from ./spec/interactor/organizer_spec.rb:3
     # ./lib/interactor.rb:50:in `call'
     # ./spec/support/lint.rb:12:in `block (3 levels) in <top (required)>'

  3) Interactor::Organizer.new initializes a context
     Failure/Error: @context = Context.build(context)

       #<Interactor::Context (class)> received :build with unexpected arguments
         expected: ({:foo=>"bar"}) (keyword arguments)
              got: ({:foo=>"bar"}) (options hash)
     Shared Example Group: :lint called from ./spec/interactor/organizer_spec.rb:3
     # ./lib/interactor.rb:9[4](https://github.com/mjacobus/interactor/actions/runs/6632281530/job/18017614115?pr=3#step:4:5):in `initialize'
     # ./spec/support/lint.rb:48:in `new'
     # ./spec/support/lint.rb:48:in `block (3 levels) in <top (required)>'

  4) Interactor.call calls an instance with the given context
     Failure/Error: new(context).tap(&:run).context

       #<#<Class:0x0000[5](https://github.com/mjacobus/interactor/actions/runs/6632281530/job/18017614115?pr=3#step:4:6)5ff[6](https://github.com/mjacobus/interactor/actions/runs/6632281530/job/18017614115?pr=3#step:4:7)08291b8> (class)> received :new with unexpected arguments
         expected: ({:foo=>"bar"}) (keyword arguments)
              got: ({:foo=>"bar"}) (options hash)
     Shared Example Group: :lint called from ./spec/interactor_spec.rb:2
     # ./lib/interactor.rb:50:in `call'
     # ./spec/support/lint.rb:12:in `block (3 levels) in <top (required)>'

  5) Interactor.call! calls an instance with the given context
     Failure/Error: new(context).tap(&:run!).context

       #<#<Class:0x000055ff608605a0> (class)> received :new with unexpected arguments
         expected: ({:foo=>"bar"}) (keyword arguments)
              got: ({:foo=>"bar"}) (options hash)
     Shared Example Group: :lint called from ./spec/interactor_spec.rb:2
     # ./lib/interactor.rb:[7](https://github.com/mjacobus/interactor/actions/runs/6632281530/job/18017614115?pr=3#step:4:8)6:in `call!'
     # ./spec/support/lint.rb:31:in `block (3 levels) in <top (required)>'

  6) Interactor.new initializes a context
     Failure/Error: @context = Context.build(context)

       #<Interactor::Context (class)> received :build with unexpected arguments
         expected: ({:foo=>"bar"}) (keyword arguments)
              got: ({:foo=>"bar"}) (options hash)
     Shared Example Group: :lint called from ./spec/interactor_spec.rb:2
     # ./lib/interactor.rb:94:in `initialize'
     # ./spec/support/lint.rb:4[8](https://github.com/mjacobus/interactor/actions/runs/6632281530/job/18017614115?pr=3#step:4:9):in `new'
     # ./spec/support/lint.rb:48:in `block (3 levels) in <top (required)>'

Finished in 0.1142[9](https://github.com/mjacobus/interactor/actions/runs/6632281530/job/18017614115?pr=3#step:4:10) seconds (files took 0.12358 seconds to load)
[10](https://github.com/mjacobus/interactor/actions/runs/6632281530/job/18017614115?pr=3#step:4:11)8 examples, 6 failures

Failed examples:

rspec './spec/interactor/organizer_spec.rb[1:2:1]' # Interactor::Organizer.call! calls an instance with the given context
rspec './spec/interactor/organizer_spec.rb[1:1:1]' # Interactor::Organizer.call calls an instance with the given context
rspec './spec/interactor/organizer_spec.rb[1:3:1]' # Interactor::Organizer.new initializes a context
rspec './spec/interactor_spec.rb[1:1:1]' # Interactor.call calls an instance with the given context
rspec './spec/interactor_spec.rb[1:2:1]' # Interactor.call! calls an instance with the given context
rspec './spec/interactor_spec.rb[1:3:1]' # Interactor.new initializes a context

Randomized with seed 586[25](https://github.com/mjacobus/interactor/actions/runs/6632281530/job/18017614115?pr=3#step:4:26)

```