### PR TITLE
Implement Interactor::Strict

### DIFF
--- a/lib/interactor/strict.rb
+++ b/lib/interactor/strict.rb
@@ -1,0 +1,38 @@
+module Interactor
+  module Strict
+    def self.included(base)
+      base.class_eval do
+        extend ClassMethods
+        include Hooks
+
+        # Public: Gets the Interactor::Context of the Interactor instance.
+        attr_reader :context
+      end
+    end
+
+    def initialize(*args, **kargs)
+      unless args.empty?
+        raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 0)"
+      end
+
+      @kargs = kargs
+      @context = Context.build(*args)
+    end
+
+    def run!
+      with_hooks do
+        call(**@kargs)
+        context.called!(self)
+      end
+    rescue
+      context.rollback!
+      raise
+    end
+
+    module ClassMethods
+      def call(*args, **kargs)
+        new(*args, **kargs).tap(&:run).context
+      end
+    end
+  end
+end

--- a/lib/interactor/strict.rb
+++ b/lib/interactor/strict.rb
@@ -33,6 +33,10 @@ module Interactor
       def call(*args, **kargs)
         new(*args, **kargs).tap(&:run).context
       end
+
+      def call!(*args, **kargs)
+        new(*args, **kargs).tap(&:run!).context
+      end
     end
   end
 end

--- a/spec/interactor/strict_spec.rb
+++ b/spec/interactor/strict_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "interactor/strict"
+
+RSpec.describe Interactor::Strict do
+  describe "keyword arguments" do
+    context "when they are defined" do
+      let(:service_class) do
+        Class.new do
+          include Interactor
+          include Interactor::Strict
+
+          before :before_one
+          before :before_two
+          after :after_one
+          after :after_two
+
+          def call(foo:, bar:, with_default: 'default')
+            context.args = [foo, bar, with_default]
+          end
+
+          def before_one
+            context.hooks = ["before_one"]
+          end
+
+          def before_two
+            context.hooks << "before_two"
+          end
+
+          def after_one
+            context.hooks << "after_one"
+          end
+
+          def after_two
+            context.hooks << "after_two"
+          end
+        end
+      end
+
+      it "works when all keyword arguments are passed" do
+        context = service_class.call(foo: "the-foo", bar: "the-bar")
+
+        expect(context.args).to eq(%w[the-foo the-bar default])
+      end
+
+      it "works with regular hooks" do
+        context = service_class.call(foo: "the-foo", bar: "the-bar")
+
+        expect(context.hooks).to eq(%w[before_one before_two after_two after_one])
+      end
+
+      it "raises when keyword arguments are not properly passed" do
+        expect { service_class.call(foo: "the-foo") }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/interactor/strict_spec.rb
+++ b/spec/interactor/strict_spec.rb
@@ -3,40 +3,52 @@
 require "interactor/strict"
 
 RSpec.describe Interactor::Strict do
-  describe "keyword arguments" do
-    context "when they are defined" do
-      let(:service_class) do
-        Class.new do
-          include Interactor
-          include Interactor::Strict
+  let(:service_class) do
+    Class.new do
+      include Interactor
+      include Interactor::Strict
 
-          before :before_one
-          before :before_two
-          after :after_one
-          after :after_two
+      before :before_one
+      before :before_two
+      after :after_one
+      after :after_two
 
-          def call(foo:, bar:, with_default: 'default')
-            context.args = [foo, bar, with_default]
-          end
-
-          def before_one
-            context.hooks = ["before_one"]
-          end
-
-          def before_two
-            context.hooks << "before_two"
-          end
-
-          def after_one
-            context.hooks << "after_one"
-          end
-
-          def after_two
-            context.hooks << "after_two"
-          end
-        end
+      def call(foo:, bar:, with_default: 'default')
+        context.args = [foo, bar, with_default]
       end
 
+      def before_one
+        context.hooks = ["before_one"]
+      end
+
+      def before_two
+        context.hooks << "before_two"
+      end
+
+      def after_one
+        context.hooks << "after_one"
+      end
+
+      def after_two
+        context.hooks << "after_two"
+      end
+    end
+  end
+
+
+  let(:loose_params_service) do
+    Class.new do
+      include Interactor
+      include Interactor::Strict
+
+      def call(foo:, bar:, **others)
+        context.args = [foo, bar, others]
+      end
+    end
+  end
+
+  describe ".call" do
+    context "when they are defined" do
       it "works when all keyword arguments are passed" do
         context = service_class.call(foo: "the-foo", bar: "the-bar")
 
@@ -49,8 +61,34 @@ RSpec.describe Interactor::Strict do
         expect(context.hooks).to eq(%w[before_one before_two after_two after_one])
       end
 
+      it "can take looser params" do
+        context = loose_params_service.call(foo: "foo", bar: "bar", other: "other")
+
+        expect(context.args).to eq(["foo", "bar", { other: "other"}])
+      end
+
       it "raises when keyword arguments are not properly passed" do
         expect { service_class.call(foo: "the-foo") }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe ".call!" do
+    context "when they are defined" do
+      it "works when all keyword arguments are passed" do
+        context = service_class.call!(foo: "the-foo", bar: "the-bar")
+
+        expect(context.args).to eq(%w[the-foo the-bar default])
+      end
+
+      it "works with regular hooks" do
+        context = service_class.call!(foo: "the-foo", bar: "the-bar")
+
+        expect(context.hooks).to eq(%w[before_one before_two after_two after_one])
+      end
+
+      it "raises when keyword arguments are not properly passed" do
+        expect { service_class.call!(foo: "the-foo") }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
This enforces param passing by using keyword args:

```ruby
class SomeService
  include Interactor
  include Interactor::Strict # that will allow you to use keywords

  def call(foo:, bar:, with_default: 'default')
    context.result = [foo, bar, with_default]
  end
end
```

Now you don't need to use comments to document your `.call` signature. Just use what ruby gives you.
